### PR TITLE
Fix Cache-Control header when cache=False.

### DIFF
--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -407,7 +407,7 @@ class Images(object):
                 image.save(fh, format, quality=quality)
                 return fh.getvalue(), 200, [
                     ('Content-Type', mimetype),
-                    ('Cache-Control', cache_timeout),
+                    ('Cache-Control', str(cache_timeout)),
                 ]
             
             makedirs(cache_dir)

--- a/tests/test_build_url.py
+++ b/tests/test_build_url.py
@@ -60,3 +60,8 @@ class TestUrlBuild(TestCase):
         parsed_url = urlsplit(url)
         self.assertEqual(parsed_url.scheme, 'https')
         self.assertEqual(parsed_url.netloc, netloc)
+
+    def test_no_cache(self):
+        url = url_for('images.crop', filename='cc.png', width=5, cache=False)
+        response = self.client.get(url)
+        self.assert200(response)


### PR DESCRIPTION
Werkzeug expects strings for headers, but `cache_timeout` is a number.

The test was broken before the change.
