### PR TITLE
Add compat for itsdangerous 2.0+

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git@github.com:mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/pallets/flask-sphinx-themes.git

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,12 @@
 
+3.0.4
+-----
+- Fix comparison between offset-aware and naive datetimes 
+
+3.0.3
+-----
+- Fix compatibility with itsdangerous 2.0+
+
 3.0.2
 -----
 - Fix a couple Python3 dict API changes.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,9 @@
 
+3.0.6
+-----
+- Fix TypeError crash when image request is missing signature parameter
+- Fix Cache-Control max_age using wrong value in send_file response
+
 3.0.4
 -----
 - Fix comparison between offset-aware and naive datetimes 

--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -435,7 +435,7 @@ class Images(object):
             image.save(cache_file, format, quality=quality)
             cache_file.close()
         
-        return send_file(cache_path, mimetype=mimetype, max_age=cache_timeout)
+        return send_file(cache_path, mimetype=mimetype, max_age=cache_mtime)
 
 
 

--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -355,11 +355,13 @@ class Images(object):
                 abort(404) # Not found.
 
         raw_mtime = os.path.getmtime(path)
-        mtime = datetime.datetime.utcfromtimestamp(raw_mtime).replace(microsecond=0)
         # log.debug('last_modified: %r' % mtime)
         # log.debug('if_modified_since: %r' % request.if_modified_since)
-        if request.if_modified_since and request.if_modified_since >= mtime:
-            return '', 304
+        if request.if_modified_since:
+            tzinfo = request.if_modified_since.tzinfo
+            mtime = datetime.datetime.fromtimestamp(raw_mtime, tz=tzinfo).replace(microsecond=0)
+            if request.if_modified_since >= mtime:
+                return '', 304
         
         mode = query.get('mode')
 

--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -433,7 +433,7 @@ class Images(object):
             image.save(cache_file, format, quality=quality)
             cache_file.close()
         
-        return send_file(cache_path, mimetype=mimetype, max_age=max_age)
+        return send_file(cache_path, mimetype=mimetype, max_age=cache_timeout)
 
 
 

--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -303,9 +303,10 @@ class Images(object):
 
         # Verify the signature.
         query = dict(iteritems(request.args))
-        old_sig = bytes(query.pop('s', None), 'utf-8')
-        if not old_sig:
+        sig = query.pop('s', None)
+        if not sig:
             abort(404)
+        old_sig = bytes(sig, 'utf-8')
         query_info = urlencode(sorted(iteritems(query)), True)
         msg_auth = hmac.new(as_bytes(current_app.secret_key),
             f'{path}?{query_info}'.encode('utf-8'),
@@ -435,7 +436,7 @@ class Images(object):
             image.save(cache_file, format, quality=quality)
             cache_file.close()
         
-        return send_file(cache_path, mimetype=mimetype, max_age=cache_mtime)
+        return send_file(cache_path, mimetype=mimetype, max_age=max_age)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
 
     name='Flask-Images',
-    version='3.0.4',
+    version='3.0.5',
     description='Dynamic image resizing for Flask.',
     url='http://github.com/mikeboers/Flask-Images',
         

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
 
     name='Flask-Images',
-    version='3.0.3',
+    version='3.0.4',
     description='Dynamic image resizing for Flask.',
     url='http://github.com/mikeboers/Flask-Images',
         

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
 
     name='Flask-Images',
-    version='3.0.2',
+    version='3.0.3',
     description='Dynamic image resizing for Flask.',
     url='http://github.com/mikeboers/Flask-Images',
         

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
 
     name='Flask-Images',
-    version='3.0.5',
+    version='3.0.6',
     description='Dynamic image resizing for Flask.',
     url='http://github.com/mikeboers/Flask-Images',
         


### PR DESCRIPTION
This PR fix #57 : I don't use `itsdangerous._compat` anymore: I directly use [hmac.compare_digest](https://docs.python.org/3/library/hmac.html#hmac.compare_digest)

The merge and the deployment onto pipy would be greatly appreciated: I really like your module :)

Best Regards